### PR TITLE
array_contains asserts elements are present in input

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,8 @@ pub enum Error<'a> {
     MissingObjectKey(&'a Value, String),
     #[error("Key '{1}' is not expected in object")]
     UnexpectedObjectKey(&'a Value, String),
+    #[error("No match for expected array element {1}")]
+    UnmatchedValidator(&'a Value, usize),
 }
 
 impl<'a> Error<'a> {
@@ -69,6 +71,7 @@ impl<'a> Error<'a> {
             Error::InvalidValue(loc, _) => loc,
             Error::MissingObjectKey(loc, _) => loc,
             Error::UnexpectedObjectKey(loc, _) => loc,
+            Error::UnmatchedValidator(loc, _) => loc,
         }
     }
 }


### PR DESCRIPTION
I find that I frequently want to assert that an array contains at least certain elements. This validator asserts that each sub validator matches a unique element in an array. This is inspired by Jest's [arrayContaining](https://jestjs.io/docs/expect#expectarraycontainingarray). Making this validator print detailed info on failure is a challenge since validators do not implement `Display`; unlike other validators, it is unordered and cannot know what element a specific sub-validator is supposed to match. Right now it uses the validator's position to say:
```
thread 'validators::array::tests::message' panicked at 'error: Invalid JSON
  ┌─ :1:1
  │
1 │ ╭ [
2 │ │     3,
3 │ │     1
4 │ │ ]
  │ ╰─^ No match for expected array element 1
```
