### PR TITLE
Expand workflow & add cargo deny

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,75 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  build-test:
+    name: Build and test (${{ matrix.os }})
+
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: swatinem/rust-cache@v2
+      - name: Build
+        run: >
+          cargo build
+          --locked
+          --verbose
+
+      - name: Run tests (without coverage)
+        run: >
+          cargo test
+          --verbose
+
+  check-clippy-and-format:
+    name: Check clippy and format
 
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      - uses: actions/checkout@v4
+      - uses: swatinem/rust-cache@v2
+
+      - name: Set up nightly toolchain
+        # Cannot be `minimal` profile, need `rustfmt` and `clippy`:
+        # https://rust-lang.github.io/rustup/concepts/profiles.html#profiles
+        run: >
+          rustup toolchain install nightly
+          && rustup component add --toolchain nightly rustfmt
+
+      - name: Check formatting
+        run: >
+          cargo +nightly fmt
+          --all
+          -- --check
+
+      - name: Check clippy
+        run: >
+          cargo clippy
+          --workspace
+          --all-targets
+          --all-features
+          -- --deny warnings
+
+  cargo-deny:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        checks:
+          - advisories
+          - bans licenses sources
+
+    # Prevent sudden announcement of a new advisory from failing ci:
+    continue-on-error: ${{ matrix.checks == 'advisories' }}
+
+    steps:
+    - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
+    - uses: EmbarkStudios/cargo-deny-action@8371184bd11e21dcf8ac82ebf8c9c9f74ebf7268
+      with:
+        command: check ${{ matrix.checks }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ jobs:
       - name: Build
         run: >
           cargo build
-          --locked
           --verbose
 
       - name: Run tests (without coverage)

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/deny.toml
+++ b/deny.toml
@@ -1,4 +1,6 @@
 # configuration for https://github.com/EmbarkStudios/cargo-deny
+[graph]
+all-features = true
 
 [licenses]
 confidence-threshold = 0.8
@@ -12,9 +14,10 @@ allow = [
 yanked = "deny"
 
 [bans]
-multiple-versions = "allow"
+multiple-versions = "deny"
+wildcards = 'deny'
 
 [sources]
 unknown-registry = "deny"
-unknown-git = "warn"
+unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,20 @@
+# configuration for https://github.com/EmbarkStudios/cargo-deny
+
+[licenses]
+confidence-threshold = 0.8
+allow = [
+    "Apache-2.0",
+    "MIT",
+    "Unicode-DFS-2016",
+]
+
+[advisories]
+yanked = "deny"
+
+[bans]
+multiple-versions = "allow"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "warn"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+group_imports = "StdExternalCrate" # Unstable
+imports_granularity = "Module"     # Unstable

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -e
+
+start=$(date -Iseconds -u)
+host_name=$(hostname)
+echo "Starting build at: ${start} on ${host_name}"
+
+export RUST_BACKTRACE="full"
+
+cargo deny check
+cargo build --verbose
+cargo test --verbose --all-features
+cargo clippy --workspace --all-targets --all-features -- --deny warnings

--- a/scripts/fmt.sh
+++ b/scripts/fmt.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -e
+
+cargo +nightly fmt --all

--- a/src/macros_utils.rs
+++ b/src/macros_utils.rs
@@ -1,12 +1,12 @@
+use std::collections::BTreeMap;
+use std::ops::Range;
+
 use codespan_reporting::diagnostic::{Diagnostic, Label};
 use codespan_reporting::files::SimpleFiles;
 use codespan_reporting::term;
 use codespan_reporting::term::termcolor;
 
-use crate::validators;
-use crate::{Error, Validator, Value};
-use std::collections::BTreeMap;
-use std::ops::Range;
+use crate::{validators, Error, Validator, Value};
 
 pub struct Input(Value);
 
@@ -176,9 +176,10 @@ impl SpanSerializer {
 
 #[cfg(test)]
 mod tests {
+    use indoc::indoc;
+
     use super::SpanSerializer;
     use crate::Value;
-    use indoc::indoc;
 
     #[test]
     fn serializer_primitive() {

--- a/src/validators/array.rs
+++ b/src/validators/array.rs
@@ -1,6 +1,6 @@
-use crate::validators;
-use crate::{Error, Validator, Value};
 use std::collections::HashSet;
+
+use crate::{validators, Error, Validator, Value};
 
 /// Match each array element to a specific validator.
 pub fn array(array_validators: Vec<Box<dyn Validator>>) -> impl Validator {
@@ -111,8 +111,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::validators;
-    use crate::{Error, Validator};
+    use crate::{validators, Error, Validator};
 
     #[test]
     fn non_array() {
@@ -190,7 +189,7 @@ mod tests {
 
         assert!(matches!(
             validator.validate(&serde_json::json!([3, 1])),
-            Err(Error::UnmatchedValidator(_, _)), 
+            Err(Error::UnmatchedValidator(_, _)),
         ));
     }
 
@@ -203,7 +202,7 @@ mod tests {
 
         assert!(matches!(
             validator.validate(&serde_json::json!([3, 1])),
-            Err(Error::UnmatchedValidator(_, _)), 
+            Err(Error::UnmatchedValidator(_, _)),
         ));
     }
 

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -1,5 +1,6 @@
-use crate::{get_value_type_id, Error, Validator, Value};
 use std::fmt::Debug;
+
+use crate::{get_value_type_id, Error, Validator, Value};
 
 mod array;
 mod object;

--- a/src/validators/object.rs
+++ b/src/validators/object.rs
@@ -1,5 +1,6 @@
-use crate::{Error, Validator, Value};
 use std::collections::HashMap;
+
+use crate::{Error, Validator, Value};
 
 /// Match if each key/value pair matches
 ///
@@ -66,8 +67,7 @@ impl Validator for ObjectValidator {
 mod tests {
     use std::collections::HashMap;
 
-    use crate::validators;
-    use crate::{Error, Validator};
+    use crate::{validators, Error, Validator};
 
     #[test]
     fn valid() {

--- a/tests/error_msg.rs
+++ b/tests/error_msg.rs
@@ -1,5 +1,4 @@
-use assert_json::assert_json;
-use assert_json::validators;
+use assert_json::{assert_json, validators};
 use indoc::indoc;
 
 macro_rules! assert_panic_output {


### PR DESCRIPTION
- Add `dependabot.yml` to check for out of date dependencies every month.
- Add `cargo {clippy,fmt}` to `github` workflow.
- Add `cargo deny` workflow to warn about yanked deps and security issues.
- Modify `github` workflow to use `ubuntu`, `macos` and `windows` OS's.
- Add a `ci.sh` and `fmt.sh` for local building and formatting.
- Add `deny.toml` a config for `cargo deny`.
- Add `rustfmt.toml` that uses the `+nightly` `group_imports` feature so imports are sorted consistently.