### PR TITLE
Only emit ANSI escapes when process is terminal

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -9,6 +9,7 @@ echo "Starting build at: ${start} on ${host_name}"
 export RUST_BACKTRACE="full"
 
 cargo deny check
+cargo +nightly fmt --all -- --check
 cargo build --verbose
 cargo test --verbose --all-features
 cargo clippy --workspace --all-targets --all-features -- --deny warnings

--- a/tests/error_msg.rs
+++ b/tests/error_msg.rs
@@ -1,4 +1,5 @@
-use std::{any::Any, io::IsTerminal as _};
+use std::any::Any;
+use std::io::IsTerminal as _;
 
 use assert_json::{assert_json, validators};
 use indoc::indoc;


### PR DESCRIPTION
When used in a CI process that isn't a TTY the build log is spammed with ANSI escapes.
This PR makes the ANSI emission conditional on whether the process is a TTY.